### PR TITLE
Add $version parameter in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,11 @@
 # Examples
 #
 #   include calibre
-class calibre {
+class calibre (
+  $version = '1.19.0'
+) {
   package { 'Calibre':
-    source   => 'http://download.calibre-ebook.com/1.19.0/calibre-1.19.0.dmg',
+    source   => "http://download.calibre-ebook.com/${version}/calibre-${version}.dmg",
     provider => 'appdmg'
   }
 }


### PR DESCRIPTION
This way the file does not need to be updated simply because a new version of Calibre comes out.

This is particularly useful when used in conjunction with hiera, since manifests can continue to use `include calibre` and there's a hiera value for `calibre::version` that gets auto-populated.
