### PR TITLE
Made some changes around the way versioning works

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 class calibre (
   $version = '1.19.0'
 ) {
-  package { 'Calibre':
+  package { "Calibre_${version}":
     source   => "http://download.calibre-ebook.com/${version}/calibre-${version}.dmg",
     provider => 'appdmg'
   }

--- a/spec/classes/calibre_spec.rb
+++ b/spec/classes/calibre_spec.rb
@@ -2,9 +2,16 @@ require 'spec_helper'
 
 describe 'calibre' do
   it do
-    should contain_package('Calibre').with({
+    should contain_package('Calibre_1.19.0').with({
       :provider => 'appdmg',
       :source   => 'http://download.calibre-ebook.com/1.19.0/calibre-1.19.0.dmg'
-    })
+      })
+  end
+
+  describe 'when specifying a specific version' do
+    let (:params) {{:version => '1.18.0'}}
+
+    it { should contain_package('Calibre_1.18.0')}
+    it { should contain_package('Calibre_1.18.0').with_source('http://download.calibre-ebook.com/1.18.0/calibre-1.18.0.dmg')}
   end
 end


### PR DESCRIPTION
The way the system checks if a version is installed is to check /var/.db/.puppet for a version, so this will ensure the new version is installed.
